### PR TITLE
Tekton - Updates to make things more explicit

### DIFF
--- a/evolve-serverless-services.md
+++ b/evolve-serverless-services.md
@@ -492,13 +492,13 @@ You will use the [Spring PetClinic](https://github.com/spring-projects/spring-pe
 
 Create the Kubernetes objects for deploying the PetClinic app on OpenShift. The deployment will not complete since there are no container images built for the PetClinic application yet. That you will do in the following sections through a CI/CD pipeline.
 
-Replace `userXX-cloudnative-pipeline` with your username in **knative/pipeline/petclinic.yaml**:
+In CodeReady Workspaces in the `payment-service` project, open the **knative/pipeline/petclinic.yaml** file. Inside it, replace `userXX` with your username:
 
 ![serverless]({% image_path petclinic-namespace.png %})
 
 Then create the object in Kubernetes:
 
-`oc create -f knative/pipeline/petclinic.yaml`
+`oc create -f /projects/cloud-native-workshop-v2m4-labs/payment-service/knative/pipeline/petclinic.yaml`
 
 You should be able to see the deployment in the [OpenShift web console]({{ CONSOLE_URL}}){:target="_blank"}.
 
@@ -545,9 +545,9 @@ creating a pipeline in the next section:
 
 Create the following Tekton tasks which will be used in the `Pipelines`:
 
-`oc create -f knative/pipeline/openshift-client-task.yaml`
+`oc create -f /projects/cloud-native-workshop-v2m4-labs/payment-service/knative/pipeline/openshift-client-task.yaml`
 
-`oc create -f knative/pipeline/s2i-java-8-task.yaml`
+`oc create -f /projects/cloud-native-workshop-v2m4-labs/payment-service/knative/pipeline/s2i-java-8-task.yaml`
 
 Let's confirm if the **tasks** are installed properly using [Tekton CLI](https://github.com/tektoncd/cli/releases){:target="_blank"} that already installed in CodeReady Workspaces.
 


### PR DESCRIPTION
Some updates to make some things more explicit in the Tekton section:

1. The instructions weren't clear where the `knative/pipeline/petclinic.yaml` file was. I updated the instructions to be more explicit
1. In other sections added the full path to the `payment-service` project in the command lines
    - This is consistent with how other labs/modules worked.